### PR TITLE
Add adoc anchors required by RV32I normative rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,16 @@ BUILD_DIR := build
 DOCS_PDF := $(addprefix $(BUILD_DIR)/, $(addsuffix .pdf, $(DOCS)))
 DOCS_HTML := $(addprefix $(BUILD_DIR)/, $(addsuffix .html, $(DOCS)))
 DOCS_EPUB := $(addprefix $(BUILD_DIR)/, $(addsuffix .epub, $(DOCS)))
+DOCS_NORM_TAGS := $(addprefix $(BUILD_DIR)/, $(addsuffix -norm-tags.json, $(DOCS)))
 
 ENV := LANG=C.utf8
 XTRA_ADOC_OPTS :=
+
 ASCIIDOCTOR_PDF := $(ENV) asciidoctor-pdf
 ASCIIDOCTOR_HTML := $(ENV) asciidoctor
 ASCIIDOCTOR_EPUB := $(ENV) asciidoctor-epub3
+ASCIIDOCTOR_TAGS := $(ENV) asciidoctor --backend tags --require=./docs-resources/converters/tags.rb
+
 OPTIONS := --trace \
            -a compress \
            -a mathematical-format=svg \
@@ -107,15 +111,17 @@ OPTIONS := --trace \
            $(WATERMARK_OPT) \
            -a revnumber='$(DATE)' \
            -a revremark='$(RELEASE_DESCRIPTION)' \
+           -a docinfo=shared \
            $(XTRA_ADOC_OPTS) \
            -D build \
            --failure-level=ERROR
 REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-diagram \
             --require=asciidoctor-lists \
-            --require=asciidoctor-mathematical
+            --require=asciidoctor-mathematical \
+            --require=asciidoctor-sail
 
-.PHONY: all build clean build-container build-no-container build-docs build-pdf build-html build-epub submodule-check
+.PHONY: all build clean build-container build-no-container build-docs build-pdf build-html build-epub build-tags submodule-check
 
 all: build
 
@@ -131,22 +137,28 @@ build-docs: $(DOCS_PDF) $(DOCS_HTML) $(DOCS_EPUB)
 build-pdf: $(DOCS_PDF)
 build-html: $(DOCS_HTML)
 build-epub: $(DOCS_EPUB)
+build-tags: $(DOCS_NORM_TAGS)
 
 ALL_SRCS := $(shell git ls-files $(SRC_DIR))
 
-$(BUILD_DIR)/%.pdf: $(SRC_DIR)/%.adoc $(ALL_SRCS)
+$(BUILD_DIR)/%.pdf: $(SRC_DIR)/%.adoc $(ALL_SRCS) $(BUILD_DIR)/%-norm-tags.json
 	$(WORKDIR_SETUP)
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
 	$(WORKDIR_TEARDOWN)
 
-$(BUILD_DIR)/%.html: $(SRC_DIR)/%.adoc $(ALL_SRCS)
+$(BUILD_DIR)/%.html: $(SRC_DIR)/%.adoc $(ALL_SRCS) $(BUILD_DIR)/%-norm-tags.json
 	$(WORKDIR_SETUP)
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_HTML) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
 	$(WORKDIR_TEARDOWN)
 
-$(BUILD_DIR)/%.epub: $(SRC_DIR)/%.adoc $(ALL_SRCS)
+$(BUILD_DIR)/%.epub: $(SRC_DIR)/%.adoc $(ALL_SRCS) $(BUILD_DIR)/%-norm-tags.json
 	$(WORKDIR_SETUP)
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_EPUB) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
+	$(WORKDIR_TEARDOWN)
+
+$(BUILD_DIR)/%-norm-tags.json: $(SRC_DIR)/%.adoc $(ALL_SRCS) docs-resources/converters/tags.rb
+	$(WORKDIR_SETUP)
+	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_TAGS) $(OPTIONS) -a tags-match-prefix='norm:' -a tags-output-suffix='-norm-tags.json' $(REQUIRES) $< $(DOCKER_QUOTE)
 	$(WORKDIR_TEARDOWN)
 
 build: submodule-check

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -86,9 +86,9 @@ to 64 bits, including on a divide by zero.#
 (((MUL, div by zero)))
 
 The semantics for division by zero and division overflow are summarized
-in <<divby0>>. [#manual:inst_group:division:div_by_zero]#The quotient of division by zero has all bits
-set#, and [#manual:inst_group:remainder:div_by_zero]#the remainder of division by zero equals the dividend.# 
-[#manual:inst_group:div_overflow]#Signed division overflow occurs only when the most-negative integer is divided
+in <<divby0>>. [#manual:instgrp:division:div_by_zero]#The quotient of division by zero has all bits
+set#, and [#manual:instgrp:remainder:div_by_zero]#the remainder of division by zero equals the dividend.# 
+[#manual:instgrp:div_overflow]#Signed division overflow occurs only when the most-negative integer is divided
 by latexmath:[$-1$]. The quotient of a signed division with overflow is
 equal to the dividend, and the remainder is zero.# Unsigned division
 overflow cannot occur.

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -22,9 +22,9 @@ include::images/wavedrom/m-st-ext-for-int-mult.edn[]
 (((MUL, MULHU)))
 (((MUL, MULHSU)))
 
-[#manual:inst:mul:operation]#MUL performs an XLEN-bit×XLEN-bit multiplication of
+[#norm:inst:mul:operation]#MUL performs an XLEN-bit×XLEN-bit multiplication of
 `rs1` by `rs2` and places the lower XLEN bits in the destination
-register.# [#manual:insts:mulh-mulhu-mulhsu:operation]#MULH, MULHU, and MULHSU perform the same multiplication but
+register.# [#norm:insts:mulh-mulhu-mulhsu:operation]#MULH, MULHU, and MULHSU perform the same multiplication but
 return the upper XLEN bits of the full 2×XLEN-bit
 product, for signed×signed,
 unsigned×unsigned, and `rs1`×unsigned `rs2` multiplication.#
@@ -37,7 +37,7 @@ most-significant word of the multiplicand (which contains the sign bit)
 with the less-significant words of the multiplier (which are unsigned).
 ====
 
-[#manual:inst:mulw:operation]#MULW is an RV64 instruction that multiplies the lower 32 bits of the
+[#norm:inst:mulw:operation]#MULW is an RV64 instruction that multiplies the lower 32 bits of the
 source registers, placing the sign extension of the lower 32 bits of the
 result into the destination register.#
 
@@ -58,9 +58,9 @@ include::images/wavedrom/division-op.edn[]
 (((MUL, DIV)))
 (((MUL, DIVU)))
 
-[#manual:insts:div-divu:operation]#DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned
-integer division of `rs1` by `rs2`, rounding towards zero.# [#manual:insts:rem-remu:operation]#REM and REMU
-provide the remainder of the corresponding division operation.# [#manual:inst:rem:result_sign]#For REM,
+[#norm:insts:div-divu:operation]#DIV and DIVU perform an XLEN bits by XLEN bits signed and unsigned
+integer division of `rs1` by `rs2`, rounding towards zero.# [#norm:insts:rem-remu:operation]#REM and REMU
+provide the remainder of the corresponding division operation.# [#norm:inst:rem:result_sign]#For REM,
 the sign of a nonzero result equals the sign of the dividend.#
 
 [NOTE]
@@ -76,19 +76,19 @@ the recommended code sequence is: `DIV[U] rdq, rs1, rs2; REM[U] rdr,`
 Microarchitectures can then fuse these into a single divide operation
 instead of performing two separate divides.
 
-[#manual:insts:divw-divuw:operation]#DIVW and DIVUW are RV64 instructions that divide the lower 32 bits of
+[#norm:insts:divw-divuw:operation]#DIVW and DIVUW are RV64 instructions that divide the lower 32 bits of
 `rs1` by the lower 32 bits of `rs2`, treating them as signed and
 unsigned integers, placing the 32-bit quotient in `rd`,
-sign-extended to 64 bits.# [#manual:insts:remw-remuw:operation]#REMW and REMUW are RV64 instructions that
+sign-extended to 64 bits.# [#norm:insts:remw-remuw:operation]#REMW and REMUW are RV64 instructions that
 provide the corresponding signed and unsigned remainder
-operations.# [#manual:insts:remw-remuw:result_sign]#BothREMW and REMUW always sign-extend the 32-bit result
+operations.# [#norm:insts:remw-remuw:result_sign]#BothREMW and REMUW always sign-extend the 32-bit result
 to 64 bits, including on a divide by zero.#
 (((MUL, div by zero)))
 
 The semantics for division by zero and division overflow are summarized
-in <<divby0>>. [#manual:instgrp:division:div_by_zero]#The quotient of division by zero has all bits
-set#, and [#manual:instgrp:remainder:div_by_zero]#the remainder of division by zero equals the dividend.# 
-[#manual:instgrp:div_overflow]#Signed division overflow occurs only when the most-negative integer is divided
+in <<divby0>>. [#norm:instgrp:division:div_by_zero]#The quotient of division by zero has all bits
+set#, and [#norm:instgrp:remainder:div_by_zero]#the remainder of division by zero equals the dividend.# 
+[#norm:instgrp:div_overflow]#Signed division overflow occurs only when the most-negative integer is divided
 by latexmath:[$-1$]. The quotient of a signed division with overflow is
 equal to the dividend, and the remainder is zero.# Unsigned division
 overflow cannot occur.

--- a/src/m-st-ext.adoc
+++ b/src/m-st-ext.adoc
@@ -87,7 +87,7 @@ to 64 bits, including on a divide by zero.#
 
 The semantics for division by zero and division overflow are summarized
 in <<divby0>>. [#norm:instgrp:division:div_by_zero]#The quotient of division by zero has all bits
-set#, and [#norm:instgrp:remainder:div_by_zero]#the remainder of division by zero equals the dividend.# 
+set#, and [#norm:instgrp:remainder:div_by_zero]#the remainder of division by zero equals the dividend.#
 [#norm:instgrp:div_overflow]#Signed division overflow occurs only when the most-negative integer is divided
 by latexmath:[$-1$]. The quotient of a signed division with overflow is
 equal to the dividend, and the remainder is zero.# Unsigned division

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -67,7 +67,7 @@ implementation allows the supported ISA to be modified. At reset, the
 Extensions field shall contain the maximal set of supported extensions,
 and "I" shall be selected over "E" if both are available.
 
-[#manual:csr:misa:disabling-extension]
+[#norm:csr:misa:disabling-extension]
 When a standard extension is disabled by clearing its bit in `misa`, the
 instructions and CSRs defined or modified by the extension revert to
 their defined or reserved behaviors as if the extension is not

--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -61,48 +61,48 @@ ISA.
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
 15+^|*RV32I Base Instruction Set*
-10+^|imm[31:12]                                    2+^|rd           2+^|0110111 <|[[manual:inst:lui:encoding]]LUI
-10+^|imm[31:12]                                    2+^|rd           2+^|0010111 <|[[manual:inst:auipc:encoding]]AUIPC
-10+^|imm[20\|10:1\|11\|19:12]                      2+^|rd           2+^|1101111 <|[[manual:inst:jal:encoding]]JAL
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|1100111 <|[[manual:inst:jalr:encoding]]JALR
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:beq:encoding]]BEQ
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bne:encoding]]BNE
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|100    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:blt:encoding]]BLT
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|101    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bge:encoding]]BGE
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|110    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bltu:encoding]]BLTU
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|111    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bgeu:encoding]]BGEU
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0000011 <|[[manual:inst:lb:encoding]]LB
- 6+^|imm[11:0]                2+^|rs1   2+^|001    2+^|rd           2+^|0000011 <|[[manual:inst:lh:encoding]]LH
- 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0000011 <|[[manual:inst:lw:encoding]]LW
- 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0000011 <|[[manual:inst:lbu:encoding]]LBU
- 6+^|imm[11:0]                2+^|rs1   2+^|101    2+^|rd           2+^|0000011 <|[[manual:inst:lbhu:encoding]]LHU
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sb:encoding]]SB
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sh:encoding]]SH
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|010    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sw:encoding]]SW
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0010011 <|[[manual:inst:addi:encoding]]ADDI
- 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0010011 <|[[manual:inst:slti:encoding]]SLTI
- 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0010011 <|[[manual:inst:sltiu:encoding]]SLTIU
- 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0010011 <|[[manual:inst:xori:encoding]]XORI
- 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0010011 <|[[manual:inst:ori:encoding]]ORI
- 6+^|imm[11:0]                2+^|rs1   2+^|111    2+^|rd           2+^|0010011 <|[[manual:inst:andi:encoding]]ANDI
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0010011 <|[[manual:inst:slli:encoding]]SLLI
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|[[manual:inst:srli:encoding]]SRLI
- 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|[[manual:inst:srai:encoding]]SRAI
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[[manual:inst:add:encoding]]ADD
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[[manual:inst:sub:encoding]]SUB
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0110011 <|[[manual:inst:sll:encoding]]SLL
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|010    2+^|rd           2+^|0110011 <|[[manual:inst:slt:encoding]]SLT
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|011    2+^|rd           2+^|0110011 <|[[manual:inst:sltu:encoding]]SLTU
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0110011 <|[[manual:inst:xor:encoding]]XOR
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[[manual:inst:srl:encoding]]SRL
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[[manual:inst:sra:encoding]]SRA
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0110011 <|[[manual:inst:or:encoding]]OR
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|[[manual:inst:and:encoding]]AND
- 3+^|fm   2+^|pred  1+^|succ  2+^|rs1   2+^|000    2+^|rd           2+^|0001111 <|[[manual:inst:fence:encoding]]FENCE
- 3+^|1000 2+^|0011  1+^|0011  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[[manual:inst:fence.tso:encoding]]FENCE.TSO
- 3+^|0000 2+^|0001  1+^|0000  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[[manual:inst:pause:encoding]]PAUSE
- 6+^|000000000000             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[[manual:inst:ecall:encoding]]ECALL
- 6+^|000000000001             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[[manual:inst:ebreak:encoding]]EBREAK
+10+^|imm[31:12]                                    2+^|rd           2+^|0110111 <|[#norm:enc:insttable:lui]#LUI#
+10+^|imm[31:12]                                    2+^|rd           2+^|0010111 <|[#norm:enc:insttable:auipc]#AUIPC#
+10+^|imm[20\|10:1\|11\|19:12]                      2+^|rd           2+^|1101111 <|[#norm:enc:insttable:jal]#JAL#
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|1100111 <|[#norm:enc:insttable:jalr]#JALR#
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:1\|11] 2+^|1100011 <|[#norm:enc:insttable:beq]#BEQ#
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:1\|11] 2+^|1100011 <|[#norm:enc:insttable:bne]#BNE#
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|100    2+^|imm[4:1\|11] 2+^|1100011 <|[#norm:enc:insttable:blt]#BLT#
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|101    2+^|imm[4:1\|11] 2+^|1100011 <|[#norm:enc:insttable:bge]#BGE#
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|110    2+^|imm[4:1\|11] 2+^|1100011 <|[#norm:enc:insttable:bltu]#BLTU#
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|111    2+^|imm[4:1\|11] 2+^|1100011 <|[#norm:enc:insttable:bgeu]#BGEU#
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:lb]#LB#
+ 6+^|imm[11:0]                2+^|rs1   2+^|001    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:lh]#LH#
+ 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:lw]#LW#
+ 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:lbu]#LBU#
+ 6+^|imm[11:0]                2+^|rs1   2+^|101    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:lbhu]#LHU#
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:0]     2+^|0100011 <|[#norm:enc:insttable:sb]#SB#
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:0]     2+^|0100011 <|[#norm:enc:insttable:sh]#SH#
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|010    2+^|imm[4:0]     2+^|0100011 <|[#norm:enc:insttable:sw]#SW#
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:addi]#ADDI#
+ 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:slti]#SLTI#
+ 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:sltiu]#SLTIU#
+ 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:xori]#XORI#
+ 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:ori]#ORI#
+ 6+^|imm[11:0]                2+^|rs1   2+^|111    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:andi]#ANDI#
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:slli]#SLLI#
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:srli]#SRLI#
+ 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|[#norm:enc:insttable:srai]#SRAI#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[[norm:enc:insttable:add]]ADD
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:sub]#SUB#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:sll]#SLL#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|010    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:slt]#SLT#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|011    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:sltu]#SLTU#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:xor]#XOR#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:srl]#SRL#
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:sra]#SRA#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:or]#OR#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:and]#AND#
+ 3+^|fm   2+^|pred  1+^|succ  2+^|rs1   2+^|000    2+^|rd           2+^|0001111 <|[#norm:enc:insttable:fence]#FENCE#
+ 3+^|1000 2+^|0011  1+^|0011  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[#norm:enc:insttable:fence.tso]#FENCE.TSO#
+ 3+^|0000 2+^|0001  1+^|0000  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[#norm:enc:insttable:pause]#PAUSE#
+ 6+^|000000000000             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[#norm:enc:insttable:ecall]#ECALL#
+ 6+^|000000000001             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[#norm:enc:insttable:ebreak]#EBREAK#
 |===
 
 <<<
@@ -119,21 +119,21 @@ ISA.
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
 15+^|*RV64I Base Instruction Set (in addition to RV32I)*
- 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0000011 <|[[manual:inst:lwu:encoding]]LWU
- 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0000011 <|[[manual:inst:ld:encoding]]LD
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|011    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sd:encoding]]SD
+ 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:lwu]#LWU#
+ 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0000011 <|[#norm:enc:insttable:ld]#LD#
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|011    2+^|imm[4:0]     2+^|0100011 <|[#norm:enc:insttable:sd]#SD#
  3+^|000000         3+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0010011 <|SLLI
  3+^|000000         3+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|SRLI
  3+^|010000         3+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|SRAI
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0011011 <|[[manual:inst:addiw:encoding]]ADDIW
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0011011 <|[[manual:inst:slliw:encoding]]SLLIW
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|[[manual:inst:srliw:encoding]]SRLIW
- 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|[[manual:inst:sraiw:encoding]]SRAIW
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[[manual:inst:addw:encoding]]ADDW
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[[manual:inst:subw:encoding]]SUBW
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0111011 <|[[manual:inst:sllw:encoding]]SLLW
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[[manual:inst:srlw:encoding]]SRLW
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[[manual:inst:sraw:encoding]]SRAW
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0011011 <|[#norm:enc:insttable:addiw]#ADDIW#
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0011011 <|[#norm:enc:insttable:slliw]#SLLIW#
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|[#norm:enc:insttable:srliw]#SRLIW#
+ 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|[#norm:enc:insttable:sraiw]#SRAIW#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:addw]#ADDW#
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:subw]#SUBW#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:sllw]#SLLW#
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:srlw]#SRLW#
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:sraw]#SRAW#
 |===
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
@@ -155,24 +155,24 @@ ISA.
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
 15+^|*RV32M Standard Extension*
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[[manual:inst:mul:encoding]]MUL
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0110011 <|[[manual:inst:mulh:encoding]]MULH
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|010    2+^|rd           2+^|0110011 <|[[manual:inst:mulhsu:encoding]]MULHSU
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|011    2+^|rd           2+^|0110011 <|[[manual:inst:mulhu:encoding]]MULHU
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0110011 <|[[manual:inst:div:encoding]]DIV
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[[manual:inst:divu:encoding]]DIVU
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0110011 <|[[manual:inst:rem:encoding]]REM
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|[[manual:inst:remu:encoding]]REMU
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:mul]#MUL#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:mulh]#MULH#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|010    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:mulhsu]#MULHSU#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|011    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:mulhu]#MULHU#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:div]#DIV#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:divu]#DIVU#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:rem]#REM#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|[#norm:enc:insttable:remu]#REMU#
 |===
 
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
 15+^|*RV64M Standard Extension (in addition to RV32M)*
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[[manual:inst:mulw:encoding]]MULW
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0111011 <|[[manual:inst:divw:encoding]]DIVW
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[[manual:inst:divuw:encoding]]DIVUW
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0111011 <|[[manual:inst:remw:encoding]]REMW
- 4+^|0000001        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0111011 <|[[manual:inst:remuw:encoding]]REMUW
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:mulw]#MULW#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:divw]#DIVW#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:divuw]#DIVUW#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:remw]#REMW#
+ 4+^|0000001        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0111011 <|[#norm:enc:insttable:remuw]#REMUW#
 |===
 
 <<<

--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -100,7 +100,7 @@ ISA.
  4+^|0000000        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|[[manual:inst:and:encoding]]AND
  3+^|fm   2+^|pred  1+^|succ  2+^|rs1   2+^|000    2+^|rd           2+^|0001111 <|[[manual:inst:fence:encoding]]FENCE
  3+^|1000 2+^|0011  1+^|0011  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[[manual:inst:fence.tso:encoding]]FENCE.TSO
- 3+^|0000 2+^|0001  1+^|0000  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|PAUSE
+ 3+^|0000 2+^|0001  1+^|0000  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[[manual:inst:pause:encoding]]PAUSE
  6+^|000000000000             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[[manual:inst:ecall:encoding]]ECALL
  6+^|000000000001             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[[manual:inst:ebreak:encoding]]EBREAK
 |===

--- a/src/rv-32-64g.adoc
+++ b/src/rv-32-64g.adoc
@@ -61,48 +61,48 @@ ISA.
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
 15+^|*RV32I Base Instruction Set*
-10+^|imm[31:12]                                    2+^|rd           2+^|0110111 <|LUI
-10+^|imm[31:12]                                    2+^|rd           2+^|0010111 <|AUIPC
-10+^|imm[20\|10:1\|11\|19:12]                      2+^|rd           2+^|1101111 <|JAL
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|1100111 <|JALR
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:1\|11] 2+^|1100011 <|BEQ
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:1\|11] 2+^|1100011 <|BNE
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|100    2+^|imm[4:1\|11] 2+^|1100011 <|BLT
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|101    2+^|imm[4:1\|11] 2+^|1100011 <|BGE
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|110    2+^|imm[4:1\|11] 2+^|1100011 <|BLTU
- 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|111    2+^|imm[4:1\|11] 2+^|1100011 <|BGEU
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0000011 <|LB
- 6+^|imm[11:0]                2+^|rs1   2+^|001    2+^|rd           2+^|0000011 <|LH
- 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0000011 <|LW
- 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0000011 <|LBU
- 6+^|imm[11:0]                2+^|rs1   2+^|101    2+^|rd           2+^|0000011 <|LHU
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:0]     2+^|0100011 <|SB
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:0]     2+^|0100011 <|SH
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|010    2+^|imm[4:0]     2+^|0100011 <|SW
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0010011 <|ADDI
- 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0010011 <|SLTI
- 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0010011 <|SLTIU
- 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0010011 <|XORI
- 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0010011 <|ORI
- 6+^|imm[11:0]                2+^|rs1   2+^|111    2+^|rd           2+^|0010011 <|ANDI
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0010011 <|SLLI
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|SRLI
- 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|SRAI
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|ADD
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|SUB
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0110011 <|SLL
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|010    2+^|rd           2+^|0110011 <|SLT
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|011    2+^|rd           2+^|0110011 <|SLTU
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0110011 <|XOR
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|SRL
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|SRA
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0110011 <|OR
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|AND
- 3+^|fm   2+^|pred  1+^|succ  2+^|rs1   2+^|000    2+^|rd           2+^|0001111 <|FENCE
- 3+^|1000 2+^|0011  1+^|0011  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|FENCE.TSO
+10+^|imm[31:12]                                    2+^|rd           2+^|0110111 <|[[manual:inst:lui:encoding]]LUI
+10+^|imm[31:12]                                    2+^|rd           2+^|0010111 <|[[manual:inst:auipc:encoding]]AUIPC
+10+^|imm[20\|10:1\|11\|19:12]                      2+^|rd           2+^|1101111 <|[[manual:inst:jal:encoding]]JAL
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|1100111 <|[[manual:inst:jalr:encoding]]JALR
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:beq:encoding]]BEQ
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bne:encoding]]BNE
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|100    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:blt:encoding]]BLT
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|101    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bge:encoding]]BGE
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|110    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bltu:encoding]]BLTU
+ 4+^|imm[12\|10:5]  2+^|rs2   2+^|rs1   2+^|111    2+^|imm[4:1\|11] 2+^|1100011 <|[[manual:inst:bgeu:encoding]]BGEU
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0000011 <|[[manual:inst:lb:encoding]]LB
+ 6+^|imm[11:0]                2+^|rs1   2+^|001    2+^|rd           2+^|0000011 <|[[manual:inst:lh:encoding]]LH
+ 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0000011 <|[[manual:inst:lw:encoding]]LW
+ 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0000011 <|[[manual:inst:lbu:encoding]]LBU
+ 6+^|imm[11:0]                2+^|rs1   2+^|101    2+^|rd           2+^|0000011 <|[[manual:inst:lbhu:encoding]]LHU
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|000    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sb:encoding]]SB
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|001    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sh:encoding]]SH
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|010    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sw:encoding]]SW
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0010011 <|[[manual:inst:addi:encoding]]ADDI
+ 6+^|imm[11:0]                2+^|rs1   2+^|010    2+^|rd           2+^|0010011 <|[[manual:inst:slti:encoding]]SLTI
+ 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0010011 <|[[manual:inst:sltiu:encoding]]SLTIU
+ 6+^|imm[11:0]                2+^|rs1   2+^|100    2+^|rd           2+^|0010011 <|[[manual:inst:xori:encoding]]XORI
+ 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0010011 <|[[manual:inst:ori:encoding]]ORI
+ 6+^|imm[11:0]                2+^|rs1   2+^|111    2+^|rd           2+^|0010011 <|[[manual:inst:andi:encoding]]ANDI
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0010011 <|[[manual:inst:slli:encoding]]SLLI
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|[[manual:inst:srli:encoding]]SRLI
+ 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|[[manual:inst:srai:encoding]]SRAI
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[[manual:inst:add:encoding]]ADD
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0110011 <|[[manual:inst:sub:encoding]]SUB
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0110011 <|[[manual:inst:sll:encoding]]SLL
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|010    2+^|rd           2+^|0110011 <|[[manual:inst:slt:encoding]]SLT
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|011    2+^|rd           2+^|0110011 <|[[manual:inst:sltu:encoding]]SLTU
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|100    2+^|rd           2+^|0110011 <|[[manual:inst:xor:encoding]]XOR
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[[manual:inst:srl:encoding]]SRL
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0110011 <|[[manual:inst:sra:encoding]]SRA
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|110    2+^|rd           2+^|0110011 <|[[manual:inst:or:encoding]]OR
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|111    2+^|rd           2+^|0110011 <|[[manual:inst:and:encoding]]AND
+ 3+^|fm   2+^|pred  1+^|succ  2+^|rs1   2+^|000    2+^|rd           2+^|0001111 <|[[manual:inst:fence:encoding]]FENCE
+ 3+^|1000 2+^|0011  1+^|0011  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|[[manual:inst:fence.tso:encoding]]FENCE.TSO
  3+^|0000 2+^|0001  1+^|0000  2+^|00000 2+^|000    2+^|00000        2+^|0001111 <|PAUSE
- 6+^|000000000000             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|ECALL
- 6+^|000000000001             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|EBREAK
+ 6+^|000000000000             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[[manual:inst:ecall:encoding]]ECALL
+ 6+^|000000000001             2+^|00000 2+^|000    2+^|00000        2+^|1110011 <|[[manual:inst:ebreak:encoding]]EBREAK
 |===
 
 <<<
@@ -119,21 +119,21 @@ ISA.
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===
 15+^|*RV64I Base Instruction Set (in addition to RV32I)*
- 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0000011 <|LWU
- 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0000011 <|LD
- 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|011    2+^|imm[4:0]     2+^|0100011 <|SD
+ 6+^|imm[11:0]                2+^|rs1   2+^|110    2+^|rd           2+^|0000011 <|[[manual:inst:lwu:encoding]]LWU
+ 6+^|imm[11:0]                2+^|rs1   2+^|011    2+^|rd           2+^|0000011 <|[[manual:inst:ld:encoding]]LD
+ 4+^|imm[11:5]      2+^|rs2   2+^|rs1   2+^|011    2+^|imm[4:0]     2+^|0100011 <|[[manual:inst:sd:encoding]]SD
  3+^|000000         3+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0010011 <|SLLI
  3+^|000000         3+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|SRLI
  3+^|010000         3+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0010011 <|SRAI
- 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0011011 <|ADDIW
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0011011 <|SLLIW
- 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|SRLIW
- 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|SRAIW
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|ADDW
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|SUBW
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0111011 <|SLLW
- 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|SRLW
- 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|SRAW
+ 6+^|imm[11:0]                2+^|rs1   2+^|000    2+^|rd           2+^|0011011 <|[[manual:inst:addiw:encoding]]ADDIW
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|001    2+^|rd           2+^|0011011 <|[[manual:inst:slliw:encoding]]SLLIW
+ 4+^|0000000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|[[manual:inst:srliw:encoding]]SRLIW
+ 4+^|0100000        2+^|shamt 2+^|rs1   2+^|101    2+^|rd           2+^|0011011 <|[[manual:inst:sraiw:encoding]]SRAIW
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[[manual:inst:addw:encoding]]ADDW
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|000    2+^|rd           2+^|0111011 <|[[manual:inst:subw:encoding]]SUBW
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|001    2+^|rd           2+^|0111011 <|[[manual:inst:sllw:encoding]]SLLW
+ 4+^|0000000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[[manual:inst:srlw:encoding]]SRLW
+ 4+^|0100000        2+^|rs2   2+^|rs1   2+^|101    2+^|rd           2+^|0111011 <|[[manual:inst:sraw:encoding]]SRAW
 |===
 [%autowidth.stretch,float="center",align="center",cols="^2m,^2m,^2m,^2m,<2m,>3m, <4m, >4m, <4m, >4m, <4m, >4m, <4m, >4m, <6m"]
 |===

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -139,7 +139,7 @@ The base ISA has `IALIGN=32`, meaning that instructions must be aligned on a fou
 [#norm:instgrp:taken_cti:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not `IALIGN-bit` aligned.
 This exception is reported on the branch or jump instruction, not on the target instruction.#
-[#norm:instgrp:cond_branch:no_ia_misaligned_exc_not_taken]#No instruction-address-misaligned exception is generated 
+[#norm:instgrp:cond_branch:no_ia_misaligned_exc_not_taken]#No instruction-address-misaligned exception is generated
 for a conditional branch that is not taken.#
 
 [NOTE]
@@ -335,7 +335,7 @@ include::images/wavedrom/int-comp-lui-aiupc.edn[]
 [[int-comp-lui-aiupc]]
 //.Integer register-immediate, U-immediate
 
-LUI (load upper immediate) is used to build 32-bit constants and uses the U-type format. 
+LUI (load upper immediate) is used to build 32-bit constants and uses the U-type format.
 [#norm:inst:lui:operation]#LUI places the 32-bit U-immediate value into the
 destination register _rd_, filling in the lowest 12 bits with zeros.#
 

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -39,13 +39,13 @@ Most of the commentary for RV32I also applies to the RV64I base.
 === Programmers' Model for Base Integer ISA
 
 <<gprs>> shows the unprivileged state for the base integer ISA. 
-[#manual:ext:I:xregs]#For RV32I, the 32 `x` registers are each 32 bits wide,
-i.e., `XLEN=32`. Register `x0` is hardwired with all bits equal to 0.
-General purpose registers `x1-x31` hold values that various
+[#norm:basegrp:rv32:xregwidth]#For RV32I, the 32 `x` registers are each 32 bits wide,
+i.e., `XLEN=32`.# [#norm:basegrp:all:x0eq0]#Register `x0` is hardwired with all bits equal to 0.#
+[#norm:bases:rv32i_rv64i:other-xregs]#General purpose registers `x1-x31` hold values that various
 instructions interpret as a collection of Boolean values, or as two's
 complement signed binary integers or unsigned binary integers.#
 
-[[manual:ext:I:pcreg]]
+[[norm:basegrp:all:pcreg]]
 There is one additional unprivileged register: the program counter `pc`
 holds the address of the current instruction.
 
@@ -136,10 +136,10 @@ RV32E subset, which only has 16 registers
 In the base RV32I ISA, there are four core instruction formats
 (R/I/S/U), as shown in <<base_instr>>. All are a fixed 32 bits in length. 
 The base ISA has `IALIGN=32`, meaning that instructions must be aligned on a four-byte boundary in memory.
-[#manual:instgrp:taken_cti:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
+[#norm:instgrp:taken_cti:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not `IALIGN-bit` aligned.
 This exception is reported on the branch or jump instruction, not on the target instruction.#
-[#manual:instgrp:cond_branch:no_ia_misaligned_exc_not_taken]#No instruction-address-misaligned exception is generated 
+[#norm:instgrp:cond_branch:no_ia_misaligned_exc_not_taken]#No instruction-address-misaligned exception is generated 
 for a conditional branch that is not taken.#
 
 [NOTE]
@@ -166,7 +166,7 @@ opcode space be used for non-conforming extensions.
 The RISC-V ISA keeps the source (_rs1_ and _rs2_) and destination (_rd_)
 registers at the same position in all formats to simplify decoding.
 Except for the 5-bit immediates used in CSR instructions (<<csrinsts>>),
-[#manual:ext:I:imm_always_sex]#immediates are always sign-extended#,
+[#norm:basegrp:all:imm_always_sex]#immediates are always sign-extended#,
 and are generally packed towards the leftmost available
 bits in the instruction and have been allocated to reduce hardware
 complexity. In particular, the sign bit for all immediates is always in
@@ -302,11 +302,11 @@ comparing the results of ADD and ADDW on the operands.
 include::images/wavedrom/integer-computational.edn[]
 //.Integer Computational Instructions
 
-[#manual:inst:addi:operation]#ADDI adds the sign-extended 12-bit immediate to register _rs1_.#
-[#manual:inst:addi:overflow]#Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.#
+[#norm:inst:addi:operation]#ADDI adds the sign-extended 12-bit immediate to register _rs1_.#
+[#norm:inst:addi:overflow]#Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.#
 ADDI _rd, rs1, 0_ is used to implement the MV _rd, rs1_ assembler pseudoinstruction.
 
-[#manual:insts:slti_sltiu:operation]#SLTI (set less than immediate) places the value 1 in register _rd_ if
+[#norm:insts:slti_sltiu:operation]#SLTI (set less than immediate) places the value 1 in register _rd_ if
 register _rs1_ is less than the sign-extended immediate when both are
 treated as signed numbers, else 0 is written to _rd_. SLTIU is similar
 but compares the values as unsigned numbers (i.e., the immediate is
@@ -314,7 +314,7 @@ first sign-extended to XLEN bits then treated as an unsigned number).#
 Note, SLTIU _rd, rs1, 1_ sets _rd_ to 1 if _rs1_ equals zero, otherwise
 sets _rd_ to 0 (assembler pseudoinstruction SEQZ _rd, rs_).
 
-[#manual:insts:andi_ori_xori:operation]#ANDI, ORI, XORI are logical operations that perform bitwise AND, OR, and
+[#norm:insts:andi_ori_xori:operation]#ANDI, ORI, XORI are logical operations that perform bitwise AND, OR, and
 XOR on register _rs1_ and the sign-extended 12-bit immediate and place
 the result in _rd_.#
 Note, XORI _rd, rs1, -1_ performs a bitwise logical inversion of register _rs1_ (assembler pseudoinstruction NOT _rd, rs_).
@@ -327,21 +327,21 @@ Shifts by a constant are encoded as a specialization of the I-type
 format. The operand to be shifted is in _rs1_, and the shift amount is
 encoded in the lower 5 bits of the I-immediate field. The right shift
 type is encoded in bit 30. 
-[#manual:inst:slli:operation]#SLLI is a logical left shift (zeros are shifted into the lower bits);#
-[#manual:inst:srli:operation]#SRLI is a logical right shift (zeros are shifted into the upper bits);# and
-[#manual:inst:srai:operation]#SRAI is an arithmetic right shift (the original sign bit is copied into the vacated upper bits).#
+[#norm:inst:slli:operation]#SLLI is a logical left shift (zeros are shifted into the lower bits);#
+[#norm:inst:srli:operation]#SRLI is a logical right shift (zeros are shifted into the upper bits);# and
+[#norm:inst:srai:operation]#SRAI is an arithmetic right shift (the original sign bit is copied into the vacated upper bits).#
 
 include::images/wavedrom/int-comp-lui-aiupc.edn[]
 [[int-comp-lui-aiupc]]
 //.Integer register-immediate, U-immediate
 
 LUI (load upper immediate) is used to build 32-bit constants and uses the U-type format. 
-[#manual:inst:lui:operation]#LUI places the 32-bit U-immediate value into the
+[#norm:inst:lui:operation]#LUI places the 32-bit U-immediate value into the
 destination register _rd_, filling in the lowest 12 bits with zeros.#
 
 AUIPC (add upper immediate to `pc`) is used to build `pc`-relative
 addresses and uses the U-type format. 
-[#manual:inst:auipc:operation]#AUIPC forms a 32-bit offset from
+[#norm:inst:auipc:operation]#AUIPC forms a 32-bit offset from
 the U-immediate, filling in the lowest 12 bits with zeros, adds this
 offset to the address of the AUIPC instruction, then places the result
 in register _rd_.#
@@ -367,7 +367,7 @@ microarchitectures.
 
 ==== Integer Register-Register Operations
 
-RV32I defines several arithmetic R-type operations. [#manual:ext:I:R-type_operands]#All operations read
+RV32I defines several arithmetic R-type operations. [#norm:basegrp:all:R-type_operands]#All operations read
 the _rs1_ and _rs2_ registers as source operands and write the result into register _rd_.#
 The _funct7_ and _funct3_ fields select the type of operation.
 
@@ -375,16 +375,16 @@ include::images/wavedrom/int-reg-reg.edn[]
 [[int-reg-reg]]
 //.Integer register-register
 
-[#manual:inst:add:operation]#ADD performs the addition of _rs1_ and _rs2_.# 
-[#manual:inst:sub:operation]#SUB performs the subtraction of _rs2_ from _rs1_.#
-[#manual:insts:add_sub:overflow]#Overflows are ignored and the low XLEN bits of results are written to the destination _rd_.# 
-[#manual:insts:slt_sltu:operation]#SLT and SLTU perform signed and unsigned compares respectively, writing 1 to _rd_ if
+[#norm:inst:add:operation]#ADD performs the addition of _rs1_ and _rs2_.# 
+[#norm:inst:sub:operation]#SUB performs the subtraction of _rs2_ from _rs1_.#
+[#norm:insts:add_sub:overflow]#Overflows are ignored and the low XLEN bits of results are written to the destination _rd_.# 
+[#norm:insts:slt_sltu:operation]#SLT and SLTU perform signed and unsigned compares respectively, writing 1 to _rd_ if
 _rs1_ < _rs2_, 0 otherwise.#
 Note, SLTU _rd_, _x0_, _rs2_ sets _rd_ to 1 if _rs2_ is not equal to zero,
 otherwise sets _rd_ to zero (assembler pseudoinstruction SNEZ _rd, rs_).
-[#manual:insts:and_or_xor:operation]#AND, OR, and XOR perform bitwise logical operations.#
+[#norm:insts:and_or_xor:operation]#AND, OR, and XOR perform bitwise logical operations.#
 
-[#manual:insts:sll_srl_sra:operation]#SLL, SRL, and SRA perform logical left, logical right, and arithmetic
+[#norm:insts:sll_srl_sra:operation]#SLL, SRL, and SRA perform logical left, logical right, and arithmetic
 right shifts on the value in register _rs1_ by the shift amount held in
 the lower 5 bits of register _rs2_.#
 
@@ -421,19 +421,19 @@ hardware.
 === Control Transfer Instructions
 RV32I provides two types of control transfer instructions: unconditional
 jumps and conditional branches. 
-[#manual:instgrp:cti:no_cti_delay_slots]#Control transfer instructions in RV32I
+[#norm:instgrp:cti:no_cti_delay_slots]#Control transfer instructions in RV32I
 do _not_ have architecturally visible delay slots.#
 
-[#manual:instgrp:cti:ia_fault_exc_on_target]#If an instruction access-fault or instruction page-fault exception
+[#norm:instgrp:cti:ia_fault_exc_on_target]#If an instruction access-fault or instruction page-fault exception
 occurs on the target of a jump or taken branch, the exception is
 reported on the target instruction, not on the jump or branch instruction.#
 
 ==== Unconditional Jumps
 The jump and link (JAL) instruction uses the J-type format, where the
 J-immediate encodes a signed offset in multiples of 2 bytes.
-[#manual:inst:jal:target]#The offset is sign-extended and added to the address of the jump instruction to
+[#norm:inst:jal:target]#The offset is sign-extended and added to the address of the jump instruction to
 form the jump target address.# Jumps can therefore target a &#177;1 MiB range.
-[#manual:inst:jal:operation]#JAL stores the address of the instruction
+[#norm:inst:jal:operation]#JAL stores the address of the instruction
 following the jump ('pc'+4) into register _rd_.#
 The standard software calling convention uses 'x1' as the return address register and 'x5' as
 an alternate link register.
@@ -456,10 +456,10 @@ include::images/wavedrom/ct-unconditional.edn[]
 //.The unconditional-jump instruction, JAL
 
 The indirect jump instruction JALR (jump and link register) uses the I-type encoding.
-[#manual:inst:jalr:target]#The target address is obtained by adding the
+[#norm:inst:jalr:target]#The target address is obtained by adding the
 sign-extended 12-bit I-immediate to the register _rs1_, then setting the
-least-significant bit of the result to zero. 
-[#manual:inst:jalr:operation]#The address of the
+least-significant bit of the result to zero.#
+[#norm:inst:jalr:operation]#The address of the
 instruction following the jump (`pc`+4) is written to register _rd_.#
 Register `x0` can be used as the destination if the result is not
 required.
@@ -559,7 +559,7 @@ is only pushed to enable macro-op fusion of the sequences:
 ==== Conditional Branches
 
 All branch instructions use the B-type instruction format. 
-[#manual:instgrp:branch:target]#The 12-bit B-immediate encodes signed offsets in multiples of 2 bytes. The offset
+[#norm:instgrp:branch:target]#The 12-bit B-immediate encodes signed offsets in multiples of 2 bytes. The offset
 is sign-extended and added to the address of the branch instruction to give the target address.#
 The conditional branch range is &#177;4 KiB.
 
@@ -568,10 +568,10 @@ include::images/wavedrom/ct-conditional.edn[]
 //.Conditional branches
 
 Branch instructions compare two registers. 
-[#manual:insts:beq_bne:operation]#BEQ and BNE take the branch if registers _rs1_ and _rs2_ are equal or unequal respectively.#
-[#manual:insts:blt_bltu:operation]#BLT and BLTU take the branch if _rs1_ is less than _rs2_, using signed and
+[#norm:insts:beq_bne:operation]#BEQ and BNE take the branch if registers _rs1_ and _rs2_ are equal or unequal respectively.#
+[#norm:insts:blt_bltu:operation]#BLT and BLTU take the branch if _rs1_ is less than _rs2_, using signed and
 unsigned comparison respectively.#
-[#manual:insts:bge_bgeu:operation]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_, 
+[#norm:insts:bge_bgeu:operation]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_, 
 using signed and unsigned comparison respectively.#
 Note, BGT, BGTU, BLE, and BLEU can be synthesized by
 reversing the operands to BLT, BLTU, BGE, and BGEU, respectively.
@@ -674,29 +674,29 @@ CPU registers. RV32I provides a 32-bit address space that is
 byte-addressed. The EEI will define what portions of the address space
 are legal to access with which instructions (e.g., some addresses might
 be read only, or support word access only).
-[#manual:instgrp:load:exc_x0]#Loads with a destination of
+[#norm:instgrp:load:exc_x0]#Loads with a destination of
 `x0` must still raise any exceptions and cause any other side effects
 even though the load value is discarded.#
 
-[#manual:param:I:endianness:little_or_big]#The EEI will define whether the memory system is little-endian or big-endian.#
-[#manual:instgrp:load_store:endian_byte_invariant]#In RISC-V, endianness is byte-address invariant.#
+[#norm:param:I:endianness:little_or_big]#The EEI will define whether the memory system is little-endian or big-endian.#
+[#norm:instgrp:load_store:endian_byte_invariant]#In RISC-V, endianness is byte-address invariant.#
 
 [NOTE]
 ====
-[[manual:instgrp:load_store:endian_byte_operation]]
+[[norm:instgrp:load_store:endian_byte_operation]]
 In a system for which endianness is byte-address invariant, the
 following property holds: if a byte is stored to memory at some address
 in some endianness, then a byte-sized load from that address in any
 endianness returns the stored value.
 
-[[manual:instgrp:load_store:little_endian_operation]]
+[[norm:instgrp:load_store:little_endian_operation]]
 In a little-endian configuration, multibyte stores write the
 least-significant register byte at the lowest memory byte address,
 followed by the other register bytes in ascending order of their
 significance. Loads similarly transfer the contents of the lesser memory
 byte addresses to the less-significant register bytes.
 
-[[manual:instgrp:load_store:big_endian_operation]]
+[[norm:instgrp:load_store:big_endian_operation]]
 In a big-endian configuration, multibyte stores write the
 most-significant register byte at the lowest memory byte address,
 followed by the other register bytes in descending order of their
@@ -710,44 +710,44 @@ include::images/wavedrom/load-store.edn[]
 
 Load and store instructions transfer a value between the registers and
 memory. Loads are encoded in the I-type format and stores are S-type.
-[#manual:instgrp:load_store:ea]#The effective address is obtained by adding register _rs1_ to the
+[#norm:instgrp:load_store:ea]#The effective address is obtained by adding register _rs1_ to the
 sign-extended 12-bit offset.# 
-[#manual:instgrp:load:operation]#Loads copy a value from memory to register _rd_.#
-[#manual:instgrp:store:operation]#Stores copy the value in register _rs2_ to memory.#
+[#norm:instgrp:load:operation]#Loads copy a value from memory to register _rd_.#
+[#norm:instgrp:store:operation]#Stores copy the value in register _rs2_ to memory.#
 
-[#manual:inst:lw:operation]#The LW instruction loads a 32-bit value from memory into _rd_.#
-[#manual:inst:lh:operation]#LH loads a 16-bit value from memory, then sign-extends to 32-bits before storing
+[#norm:inst:lw:operation]#The LW instruction loads a 32-bit value from memory into _rd_.#
+[#norm:inst:lh:operation]#LH loads a 16-bit value from memory, then sign-extends to 32-bits before storing
 in _rd_.#
-[#manual:inst:lhu:operation]#LHU loads a 16-bit value from memory but then zero extends to
+[#norm:inst:lhu:operation]#LHU loads a 16-bit value from memory but then zero extends to
 32-bits before storing in _rd_.# 
-[#manual:insts:lb_lbu:operation]#LB and LBU are defined analogously for 8-bit values.#
-[#manual:insts:sw_sh_sb:operation]#The SW, SH, and SB instructions store 32-bit, 16-bit, and
+[#norm:insts:lb_lbu:operation]#LB and LBU are defined analogously for 8-bit values.#
+[#norm:insts:sw_sh_sb:operation]#The SW, SH, and SB instructions store 32-bit, 16-bit, and
 8-bit values from the low bits of register _rs2_ to memory.#
 
-Regardless of EEI, [#manual:instgrp:load_store:no_exc_aligned]#loads and stores whose effective addresses are
+Regardless of EEI, [#norm:instgrp:load_store:no_exc_aligned]#loads and stores whose effective addresses are
 naturally aligned shall not raise an address-misaligned exception.#
-[#manual:param:I:misaligned_ldst:eei_dependent_behavior]#Loads and stores whose effective address is not naturally aligned to the
+[#norm:param:I:misaligned_ldst:eei_dependent_behavior]#Loads and stores whose effective address is not naturally aligned to the
 referenced datatype (i.e., the effective address is not divisible by the
 size of the access in bytes) have behavior dependent on the EEI.#
 
 An EEI may guarantee that misaligned loads and stores are fully
 supported, and so the software running inside the execution environment
 will never experience a contained or fatal address-misaligned trap. In this case, the
-[#manual:param:I:misaligned_ldst:fully_hw_supported]#misaligned loads and stores can be handled in hardware#, or 
-[#manual:param:I:misaligned_ldst:invisible_trap]#via an invisible trap into the execution environment implementation#, or possibly a
-[#manual:param:I:misaligned_ldst:hw_or_invisible_trap_func_of_addr]#combination of hardware and invisible trap depending on address.#
+[#norm:param:I:misaligned_ldst:fully_hw_supported]#misaligned loads and stores can be handled in hardware#, or 
+[#norm:param:I:misaligned_ldst:invisible_trap]#via an invisible trap into the execution environment implementation#, or possibly a
+[#norm:param:I:misaligned_ldst:hw_or_invisible_trap_func_of_addr]#combination of hardware and invisible trap depending on address.#
 
 An EEI may not guarantee misaligned loads and stores are handled invisibly. In this case, 
-[#manual:param:I:misaligned_ldst:fully_hw_supported_or_visible_trap]#loads and stores that are not naturally aligned
+[#norm:param:I:misaligned_ldst:fully_hw_supported_or_visible_trap]#loads and stores that are not naturally aligned
 may either complete execution successfully or raise an exception.#
-[#manual:instgrp:load_store:addr_misaligned_or_access_fault_exc]#The exception raised can be either an
+[#norm:instgrp:load_store:addr_misaligned_or_access_fault_exc]#The exception raised can be either an
 address-misaligned exception or an access-fault exception.
 For a memory access that would otherwise be able
 to complete except for the misalignment, an access-fault exception can
 be raised instead of an address-misaligned exception if the misaligned
 access should not be emulated, e.g., if accesses to the memory region
 have side effects.#
-[#manual:param:I:misaligned_ldst:contained_or_fatal_trap]#When an EEI does not guarantee misaligned loads and
+[#norm:param:I:misaligned_ldst:contained_or_fatal_trap]#When an EEI does not guarantee misaligned loads and
 stores are handled invisibly, the EEI must define if exceptions caused
 by address misalignment result in a contained trap (allowing software
 running inside the execution environment to handle the trap) or a fatal
@@ -779,7 +779,7 @@ very simplified addressing modes (e.g., register indirect only).
 Even when misaligned loads and stores complete successfully, these
 accesses might run extremely slowly depending on the implementation
 (e.g., when implemented via an invisible trap). Furthermore, whereas
-[#manual:instgrp:load_store:atomicity_for_aligned]#naturally aligned 
+[#norm:instgrp:load_store:atomicity_for_aligned]#naturally aligned 
 loads and stores are guaranteed to execute atomically#,
 misaligned loads and stores might not, and hence require additional
 synchronization to ensure atomicity.
@@ -850,13 +850,13 @@ FENCE instruction.
 |===
 
 The FENCE mode field _fm_ defines the semantics of the FENCE instruction. 
-[#manual:inst:fence:operation]#A `FENCE`
+[#norm:inst:fence:operation]#A `FENCE`
 (with _fm_=`0000`) orders all memory operations in its predecessor set
 before all memory operations in its successor set.#
 
 A `FENCE.TSO` instruction is encoded as a FENCE instruction
 with _fm_=`1000`, _predecessor_=`RW`, and _successor_=`RW`. 
-[#manual:inst:fence.tso:operation]#`FENCE.TSO` orders
+[#norm:inst:fence.tso:operation]#`FENCE.TSO` orders
 all load operations in its predecessor set before all memory operations
 in its successor set, and all store operations in its predecessor set
 before all store operations in its successor set. This leaves `non-AMO`
@@ -865,12 +865,12 @@ store operations in the `FENCE.TSO's` predecessor set unordered with
 
 [NOTE]
 ====
-[[manual:inst:fence.tso:ordering_rw_rw_allowed]]
+[[norm:inst:fence.tso:ordering_rw_rw_allowed]]
 Because `FENCE RW,RW` imposes a superset of the orderings that `FENCE.TSO`
 imposes, it is correct to ignore the _fm_ field and implement `FENCE.TSO` as `FENCE RW,RW`.
 ====
 
-[#manual:inst:fence:unused_fields_reserved]#The unused fields in the FENCE 
+[#norm:inst:fence:unused_fields_reserved]#The unused fields in the FENCE 
 instructions--_rs1_ and _rd_--are reserved
 for finer-grain fences in future extensions. For forward compatibility,
 base implementations shall ignore these fields#, and standard software
@@ -882,7 +882,7 @@ non-reserved configurations.
 
 [NOTE]
 ====
-[[manual:inst:fence:conservative_allowed]]
+[[norm:inst:fence:conservative_allowed]]
 We chose a relaxed memory model to allow high performance from simple
 machine implementations and from likely future coprocessor or
 accelerator extensions. We separate out I/O ordering from memory R/W
@@ -919,12 +919,12 @@ include::images/wavedrom/env-call-breakpoint.edn[]
 These two instructions cause a precise requested trap to the supporting
 execution environment.
 
-[#manual:inst:ecall:operation]#The `ECALL` instruction is used to make a service request to the execution environment.#
+[#norm:inst:ecall:operation]#The `ECALL` instruction is used to make a service request to the execution environment.#
 The `EEI` will define how parameters for the service request
 are passed, but usually these will be in defined locations in the
 integer register file.
 
-[#manual:inst:ebreak:operation]#The `EBREAK` instruction is used to return control to a debugging environment.#
+[#norm:inst:ebreak:operation]#The `EBREAK` instruction is used to return control to a debugging environment.#
 
 [NOTE]
 ====
@@ -999,7 +999,7 @@ _rs1_ and _rs2_ fields encode arguments to the HINT. However, a simple
 implementation can simply execute the HINT as an ADD of _rs1_ and _rs2_
 that writes `x0`, which has no architecturally visible effect.
 
-[[manual:inst:fence:null_pred_succ_intersection]]
+[[norm:inst:fence:null_pred_succ_intersection]]
 As another example, a FENCE instruction with a zero _pred_ field and a
 zero _fm_ field is a HINT; the _succ_, _rs1_, and _rd_ fields encode the
 arguments to the HINT. A simple implementation can simply execute the

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -38,15 +38,15 @@ Most of the commentary for RV32I also applies to the RV64I base.
 
 === Programmers' Model for Base Integer ISA
 
-<<gprs>> shows the unprivileged state for the base
-integer ISA. For RV32I, the 32 `x` registers are each 32 bits wide,
+<<gprs>> shows the unprivileged state for the base integer ISA. 
+[#manual:ext:I:xregs]#For RV32I, the 32 `x` registers are each 32 bits wide,
 i.e., `XLEN=32`. Register `x0` is hardwired with all bits equal to 0.
 General purpose registers `x1-x31` hold values that various
 instructions interpret as a collection of Boolean values, or as two's
-complement signed binary integers or unsigned binary integers.
+complement signed binary integers or unsigned binary integers.#
 
-There is one additional unprivileged register: the program counter `pc`
-holds the address of the current instruction.
+[#manual:ext:I:pcreg]#There is one additional unprivileged register: the program counter `pc`
+holds the address of the current instruction.#
 
 [[gprs]]
 .RISC-V base unprivileged integer register state.
@@ -133,13 +133,14 @@ RV32E subset, which only has 16 registers
 ====
 === Base Instruction Formats
 In the base RV32I ISA, there are four core instruction formats
-(R/I/S/U), as shown in <<base_instr>>. All are a fixed 32
-bits in length. The base ISA has `IALIGN=32`, meaning that instructions must be aligned on a four-byte boundary in memory. An
-instruction-address-misaligned exception is generated on a taken branch
+(R/I/S/U), as shown in <<base_instr>>. All are a fixed 32 bits in length. 
+[#manual:ext:I:ialign32]#The base ISA has `IALIGN=32`, 
+meaning that instructions must be aligned on a four-byte boundary in memory.#
+[#manual:ext:I:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not `IALIGN-bit` aligned.
-This exception is reported on the branch or jump instruction, not on the
-target instruction. No instruction-address-misaligned exception is
-generated for a conditional branch that is not taken.
+This exception is reported on the branch or jump instruction, not on the target instruction.#
+[#manual:ext:I:no_ia_misaligned_exc_not_taken_br]#No instruction-address-misaligned exception is generated 
+for a conditional branch that is not taken.#
 
 [NOTE]
 ====
@@ -164,9 +165,9 @@ opcode space be used for non-conforming extensions.
 
 The RISC-V ISA keeps the source (_rs1_ and _rs2_) and destination (_rd_)
 registers at the same position in all formats to simplify decoding.
-Except for the 5-bit immediates used in CSR instructions
-(<<csrinsts>>), immediates are always
-sign-extended, and are generally packed towards the leftmost available
+Except for the 5-bit immediates used in CSR instructions (<<csrinsts>>),
+[#manual:ext:I:imm_always_sex]#immediates are always sign-extended#,
+and are generally packed towards the leftmost available
 bits in the instruction and have been allocated to reduce hardware
 complexity. In particular, the sign bit for all immediates is always in
 bit 31 of the instruction to speed sign-extension circuitry.
@@ -301,23 +302,22 @@ comparing the results of ADD and ADDW on the operands.
 include::images/wavedrom/integer-computational.edn[]
 //.Integer Computational Instructions
 
-ADDI adds the sign-extended 12-bit immediate to register _rs1_.
-Arithmetic overflow is ignored and the result is simply the low XLEN
-bits of the result. ADDI _rd, rs1, 0_ is used to implement the MV _rd,
-rs1_ assembler pseudoinstruction.
+[#manual:inst:addi:operation]#ADDI adds the sign-extended 12-bit immediate to register _rs1_.#
+[#manual:inst:addi:overflow]#Arithmetic overflow is ignored and the result is simply the low XLEN bits of the result.#
+ADDI _rd, rs1, 0_ is used to implement the MV _rd, rs1_ assembler pseudoinstruction.
 
-SLTI (set less than immediate) places the value 1 in register _rd_ if
+[#manual:insts:slti_sltiu:operation]#SLTI (set less than immediate) places the value 1 in register _rd_ if
 register _rs1_ is less than the sign-extended immediate when both are
 treated as signed numbers, else 0 is written to _rd_. SLTIU is similar
 but compares the values as unsigned numbers (i.e., the immediate is
-first sign-extended to XLEN bits then treated as an unsigned number).
+first sign-extended to XLEN bits then treated as an unsigned number).#
 Note, SLTIU _rd, rs1, 1_ sets _rd_ to 1 if _rs1_ equals zero, otherwise
 sets _rd_ to 0 (assembler pseudoinstruction SEQZ _rd, rs_).
 
-ANDI, ORI, XORI are logical operations that perform bitwise AND, OR, and
+[#manual:insts:andi_ori_xori:operation]#ANDI, ORI, XORI are logical operations that perform bitwise AND, OR, and
 XOR on register _rs1_ and the sign-extended 12-bit immediate and place
-the result in _rd_. Note, XORI _rd, rs1, -1_ performs a bitwise logical
-inversion of register _rs1_ (assembler pseudoinstruction NOT _rd, rs_).
+the result in _rd_.#
+Note, XORI _rd, rs1, -1_ performs a bitwise logical inversion of register _rs1_ (assembler pseudoinstruction NOT _rd, rs_).
 
 include::images/wavedrom/int-comp-slli-srli-srai.edn[]
 [[int-comp-slli-srli-srai]]
@@ -326,24 +326,25 @@ include::images/wavedrom/int-comp-slli-srli-srai.edn[]
 Shifts by a constant are encoded as a specialization of the I-type
 format. The operand to be shifted is in _rs1_, and the shift amount is
 encoded in the lower 5 bits of the I-immediate field. The right shift
-type is encoded in bit 30. SLLI is a logical left shift (zeros are
-shifted into the lower bits); SRLI is a logical right shift (zeros are
-shifted into the upper bits); and SRAI is an arithmetic right shift (the
-original sign bit is copied into the vacated upper bits).
+type is encoded in bit 30. 
+[#manual:inst:slli:operation]#SLLI is a logical left shift (zeros are shifted into the lower bits);#
+[#manual:inst:srli:operation]#SRLI is a logical right shift (zeros are shifted into the upper bits);# and
+[#manual:inst:srai:operation]#SRAI is an arithmetic right shift (the original sign bit is copied into the vacated upper bits).#
 
 include::images/wavedrom/int-comp-lui-aiupc.edn[]
 [[int-comp-lui-aiupc]]
 //.Integer register-immediate, U-immediate
 
-LUI (load upper immediate) is used to build 32-bit constants and uses
-the U-type format. LUI places the 32-bit U-immediate value into the
-destination register _rd_, filling in the lowest 12 bits with zeros.
+LUI (load upper immediate) is used to build 32-bit constants and uses the U-type format. 
+[#manual:inst:lui:operation]#LUI places the 32-bit U-immediate value into the
+destination register _rd_, filling in the lowest 12 bits with zeros.#
 
 AUIPC (add upper immediate to `pc`) is used to build `pc`-relative
-addresses and uses the U-type format. AUIPC forms a 32-bit offset from
+addresses and uses the U-type format. 
+[#manual:inst:auipc:operation]#AUIPC forms a 32-bit offset from
 the U-immediate, filling in the lowest 12 bits with zeros, adds this
 offset to the address of the AUIPC instruction, then places the result
-in register _rd_.
+in register _rd_.#
 
 [NOTE]
 ====
@@ -366,27 +367,27 @@ microarchitectures.
 
 ==== Integer Register-Register Operations
 
-RV32I defines several arithmetic R-type operations. All operations read
+[#manual:ext:I:R-type_operands]#RV32I defines several arithmetic R-type operations. All operations read
 the _rs1_ and _rs2_ registers as source operands and write the result
-into register _rd_. The _funct7_ and _funct3_ fields select the type of
-operation.
+into register _rd_.#
+The _funct7_ and _funct3_ fields select the type of operation.
 
 include::images/wavedrom/int-reg-reg.edn[]
 [[int-reg-reg]]
 //.Integer register-register
 
-ADD performs the addition of _rs1_ and _rs2_. SUB performs the
-subtraction of _rs2_ from _rs1_. Overflows are ignored and the low XLEN
-bits of results are written to the destination _rd_. SLT and SLTU
-perform signed and unsigned compares respectively, writing 1 to _rd_ if
-_rs1_ < _rs2_, 0 otherwise. Note, SLTU _rd_, _x0_, _rs2_ sets _rd_ to 1 if
-_rs2_ is not equal to zero, otherwise sets _rd_ to zero (assembler
-pseudoinstruction SNEZ _rd, rs_). AND, OR, and XOR perform bitwise
-logical operations.
+[#manual:inst:add:operation]#ADD performs the addition of _rs1_ and _rs2_.# 
+[#manual:inst:sub:operation]#SUB performs the subtraction of _rs2_ from _rs1_.#
+[#manual:insts:add_sub:overflow]#Overflows are ignored and the low XLEN bits of results are written to the destination _rd_.# 
+[#manual:insts:slt_sltu:operation]#SLT and SLTU perform signed and unsigned compares respectively, writing 1 to _rd_ if
+_rs1_ < _rs2_, 0 otherwise.#
+Note, SLTU _rd_, _x0_, _rs2_ sets _rd_ to 1 if _rs2_ is not equal to zero,
+otherwise sets _rd_ to zero (assembler pseudoinstruction SNEZ _rd, rs_).
+[#manual:insts:and_or_xor:operation]#AND, OR, and XOR perform bitwise logical operations.#
 
-SLL, SRL, and SRA perform logical left, logical right, and arithmetic
+[#manual:insts:sll_srl_sra:operation]#SLL, SRL, and SRA perform logical left, logical right, and arithmetic
 right shifts on the value in register _rs1_ by the shift amount held in
-the lower 5 bits of register _rs2_.
+the lower 5 bits of register _rs2_.#
 
 ==== NOP Instruction
 
@@ -420,13 +421,13 @@ hardware.
 
 === Control Transfer Instructions
 RV32I provides two types of control transfer instructions: unconditional
-jumps and conditional branches. Control transfer instructions in RV32I
-do _not_ have architecturally visible delay slots.
+jumps and conditional branches. 
+[#manual:ext:I:no_cti_delay_slots]#Control transfer instructions in RV32I
+do _not_ have architecturally visible delay slots.#
 
-If an instruction access-fault or instruction page-fault exception
+[#manual:ext:I:ia_fault_exc_on_target]#If an instruction access-fault or instruction page-fault exception
 occurs on the target of a jump or taken branch, the exception is
-reported on the target instruction, not on the jump or branch
-instruction.
+reported on the target instruction, not on the jump or branch instruction.#
 
 ==== Unconditional Jumps
 The jump and link (JAL) instruction uses the J-type format, where the

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -45,8 +45,9 @@ General purpose registers `x1-x31` hold values that various
 instructions interpret as a collection of Boolean values, or as two's
 complement signed binary integers or unsigned binary integers.#
 
-[#manual:ext:I:pcreg]#There is one additional unprivileged register: the program counter `pc`
-holds the address of the current instruction.#
+[[manual:ext:I:pcreg]]
+There is one additional unprivileged register: the program counter `pc`
+holds the address of the current instruction.
 
 [[gprs]]
 .RISC-V base unprivileged integer register state.
@@ -134,8 +135,7 @@ RV32E subset, which only has 16 registers
 === Base Instruction Formats
 In the base RV32I ISA, there are four core instruction formats
 (R/I/S/U), as shown in <<base_instr>>. All are a fixed 32 bits in length. 
-[#manual:ext:I:ialign32]#The base ISA has `IALIGN=32`, 
-meaning that instructions must be aligned on a four-byte boundary in memory.#
+The base ISA has `IALIGN=32`, meaning that instructions must be aligned on a four-byte boundary in memory.
 [#manual:ext:I:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not `IALIGN-bit` aligned.
 This exception is reported on the branch or jump instruction, not on the target instruction.#
@@ -367,9 +367,8 @@ microarchitectures.
 
 ==== Integer Register-Register Operations
 
-[#manual:ext:I:R-type_operands]#RV32I defines several arithmetic R-type operations. All operations read
-the _rs1_ and _rs2_ registers as source operands and write the result
-into register _rd_.#
+RV32I defines several arithmetic R-type operations. [#manual:ext:I:R-type_operands]#All operations read
+the _rs1_ and _rs2_ registers as source operands and write the result into register _rd_.#
 The _funct7_ and _funct3_ fields select the type of operation.
 
 include::images/wavedrom/int-reg-reg.edn[]
@@ -433,10 +432,10 @@ reported on the target instruction, not on the jump or branch instruction.#
 The jump and link (JAL) instruction uses the J-type format, where the
 J-immediate encodes a signed offset in multiples of 2 bytes. The offset
 is sign-extended and added to the address of the jump instruction to
-form the jump target address. Jumps can therefore target a
-&#177;1 MiB range. JAL stores the address of the instruction
-following the jump ('pc'+4) into register _rd_. The standard software
-calling convention uses 'x1' as the return address register and 'x5' as
+form the jump target address. Jumps can therefore target a &#177;1 MiB range.
+[#manual:inst:jal:operation]#JAL stores the address of the instruction
+following the jump ('pc'+4) into register _rd_.#
+The standard software calling convention uses 'x1' as the return address register and 'x5' as
 an alternate link register.
 
 [NOTE]
@@ -456,11 +455,11 @@ include::images/wavedrom/ct-unconditional.edn[]
 [[ct-unconditional]]
 //.The unconditional-jump instruction, JAL
 
-The indirect jump instruction JALR (jump and link register) uses the
-I-type encoding. The target address is obtained by adding the
+The indirect jump instruction JALR (jump and link register) uses the I-type encoding.
+[#manual:inst:jalr:target]#The target address is obtained by adding the
 sign-extended 12-bit I-immediate to the register _rs1_, then setting the
 least-significant bit of the result to zero. The address of the
-instruction following the jump (`pc`+4) is written to register _rd_.
+instruction following the jump (`pc`+4) is written to register _rd_.#
 Register `x0` can be used as the destination if the result is not
 required.
 
@@ -558,22 +557,22 @@ is only pushed to enable macro-op fusion of the sequences:
 
 ==== Conditional Branches
 
-All branch instructions use the B-type instruction format. The 12-bit
-B-immediate encodes signed offsets in multiples of 2 bytes. The offset
-is sign-extended and added to the address of the branch instruction to
-give the target address. The conditional branch range is
-&#177;4 KiB.
+All branch instructions use the B-type instruction format. 
+[#manual:instgrp:branch:target]#The 12-bit B-immediate encodes signed offsets in multiples of 2 bytes. The offset
+is sign-extended and added to the address of the branch instruction to give the target address.#
+The conditional branch range is &#177;4 KiB.
 
 include::images/wavedrom/ct-conditional.edn[]
 [[ct-conditional]]
 //.Conditional branches
 
-Branch instructions compare two registers. BEQ and BNE take the branch
-if registers _rs1_ and _rs2_ are equal or unequal respectively. BLT and
-BLTU take the branch if _rs1_ is less than _rs2_, using signed and
-unsigned comparison respectively. BGE and BGEU take the branch if _rs1_
-is greater than or equal to _rs2_, using signed and unsigned comparison
-respectively. Note, BGT, BGTU, BLE, and BLEU can be synthesized by
+Branch instructions compare two registers. 
+[#manual:insts:beq_bne:cmp]#BEQ and BNE take the branch if registers _rs1_ and _rs2_ are equal or unequal respectively.#
+[#manual:insts:blt_bltu:cmp]#BLT and BLTU take the branch if _rs1_ is less than _rs2_, using signed and
+unsigned comparison respectively.#
+[#manual:insts:bge_bgeu:cmp]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_, 
+using signed and unsigned comparison respectively.#
+Note, BGT, BGTU, BLE, and BLEU can be synthesized by
 reversing the operands to BLT, BLTU, BGE, and BGEU, respectively.
 
 [NOTE]
@@ -673,26 +672,30 @@ instructions access memory and arithmetic instructions only operate on
 CPU registers. RV32I provides a 32-bit address space that is
 byte-addressed. The EEI will define what portions of the address space
 are legal to access with which instructions (e.g., some addresses might
-be read only, or support word access only). Loads with a destination of
+be read only, or support word access only).
+[#manual:instgrp:load:exc_x0]#Loads with a destination of
 `x0` must still raise any exceptions and cause any other side effects
-even though the load value is discarded.
+even though the load value is discarded.#
 
-The EEI will define whether the memory system is little-endian or
-big-endian. In RISC-V, endianness is byte-address invariant.
+[#manual:param:I:endianness:little_or_big]#The EEI will define whether the memory system is little-endian or big-endian.#
+[#manual:instgrp:load_store:endian_byte_invariant:]#In RISC-V, endianness is byte-address invariant.#
 
 [NOTE]
 ====
+[[manual:instgrp:load_store:endian_byte_operation]]
 In a system for which endianness is byte-address invariant, the
 following property holds: if a byte is stored to memory at some address
 in some endianness, then a byte-sized load from that address in any
 endianness returns the stored value.
 
+[[manual:instgrp:load_store:little_endian_operation]]
 In a little-endian configuration, multibyte stores write the
 least-significant register byte at the lowest memory byte address,
 followed by the other register bytes in ascending order of their
 significance. Loads similarly transfer the contents of the lesser memory
 byte addresses to the less-significant register bytes.
 
+[[manual:instgrp:load_store:big_endian_operation]]
 In a big-endian configuration, multibyte stores write the
 most-significant register byte at the lowest memory byte address,
 followed by the other register bytes in descending order of their
@@ -706,44 +709,48 @@ include::images/wavedrom/load-store.edn[]
 
 Load and store instructions transfer a value between the registers and
 memory. Loads are encoded in the I-type format and stores are S-type.
-The effective address is obtained by adding register _rs1_ to the
-sign-extended 12-bit offset. Loads copy a value from memory to register
-_rd_. Stores copy the value in register _rs2_ to memory.
+[#manual:instgrp:load_store:ea]#The effective address is obtained by adding register _rs1_ to the
+sign-extended 12-bit offset.# 
+[#manual:instgrp:load:operation]#Loads copy a value from memory to register _rd_.#
+[#manual:instgrp:store:operation]#Stores copy the value in register _rs2_ to memory.#
 
-The LW instruction loads a 32-bit value from memory into _rd_. LH loads
-a 16-bit value from memory, then sign-extends to 32-bits before storing
-in _rd_. LHU loads a 16-bit value from memory but then zero extends to
-32-bits before storing in _rd_. LB and LBU are defined analogously for
-8-bit values. The SW, SH, and SB instructions store 32-bit, 16-bit, and
-8-bit values from the low bits of register _rs2_ to memory.
+[#manual:inst:lw:operation]#The LW instruction loads a 32-bit value from memory into _rd_.#
+[#manual:inst:lh:operation]#LH loads a 16-bit value from memory, then sign-extends to 32-bits before storing
+in _rd_.#
+[#manual:inst:lhu:operation]#LHU loads a 16-bit value from memory but then zero extends to
+32-bits before storing in _rd_.# 
+[#manual:insts:lb_lhu:operation]#LB and LBU are defined analogously for 8-bit values.#
+[#manual:insts:sw_sh_sb:operation]#The SW, SH, and SB instructions store 32-bit, 16-bit, and
+8-bit values from the low bits of register _rs2_ to memory.#
 
-Regardless of EEI, loads and stores whose effective addresses are
-naturally aligned shall not raise an address-misaligned exception. Loads
-and stores whose effective address is not naturally aligned to the
+Regardless of EEI, [#manual:instgrp:load_store:no_exc_aligned]#loads and stores whose effective addresses are
+naturally aligned shall not raise an address-misaligned exception.#
+[#manual:param:I:misaligned_ldst:eei_dependent_behavior]#Loads and stores whose effective address is not naturally aligned to the
 referenced datatype (i.e., the effective address is not divisible by the
-size of the access in bytes) have behavior dependent on the EEI.
+size of the access in bytes) have behavior dependent on the EEI.#
 
 An EEI may guarantee that misaligned loads and stores are fully
 supported, and so the software running inside the execution environment
-will never experience a contained or fatal address-misaligned trap. In
-this case, the misaligned loads and stores can be handled in hardware,
-or via an invisible trap into the execution environment implementation,
-or possibly a combination of hardware and invisible trap depending on
-address.
+will never experience a contained or fatal address-misaligned trap. In this case, the
+[#manual:param:I:misaligned_ldst:fully_hw_supported]#misaligned loads and stores can be handled in hardware#, or 
+[#manual:param:I:misaligned_ldst:invisible_trap]#via an invisible trap into the execution environment implementation#, or possibly a
+[#manual:param:I:misaligned_ldst:hw_or_invisible_trap_func_of_addr]#combination of hardware and invisible trap depending on address.#
 
-An EEI may not guarantee misaligned loads and stores are handled
-invisibly. In this case, loads and stores that are not naturally aligned
-may either complete execution successfully or raise an exception. The
-exception raised can be either an address-misaligned exception or an
-access-fault exception. For a memory access that would otherwise be able
+An EEI may not guarantee misaligned loads and stores are handled invisibly. In this case, 
+[#manual:param:I:misaligned_ldst:fully_hw_supported_or_visible_trap]#loads and stores that are not naturally aligned
+may either complete execution successfully or raise an exception.#
+[#manual:instgrp:load_store:addr_misaligned_or_access_fault_exc]#The exception raised can be either an
+address-misaligned exception or an access-fault exception.
+For a memory access that would otherwise be able
 to complete except for the misalignment, an access-fault exception can
 be raised instead of an address-misaligned exception if the misaligned
 access should not be emulated, e.g., if accesses to the memory region
-have side effects. When an EEI does not guarantee misaligned loads and
+have side effects.#
+[#manual:param:I:misaligned_ldst:contained_or_fatal_trap]#When an EEI does not guarantee misaligned loads and
 stores are handled invisibly, the EEI must define if exceptions caused
 by address misalignment result in a contained trap (allowing software
 running inside the execution environment to handle the trap) or a fatal
-trap (terminating execution).
+trap (terminating execution).#
 
 [NOTE]
 ====
@@ -771,7 +778,8 @@ very simplified addressing modes (e.g., register indirect only).
 Even when misaligned loads and stores complete successfully, these
 accesses might run extremely slowly depending on the implementation
 (e.g., when implemented via an invisible trap). Furthermore, whereas
-naturally aligned loads and stores are guaranteed to execute atomically,
+[#manual:instgrp:load_store:atomicity_for_aligned]#naturally aligned 
+loads and stores are guaranteed to execute atomically#,
 misaligned loads and stores might not, and hence require additional
 synchronization to ensure atomicity.
 
@@ -840,27 +848,31 @@ FENCE instruction.
 |_other_|_other_ |_Reserved for future use._
 |===
 
-The FENCE mode field _fm_ defines the semantics of the FENCE instruction. A `FENCE`
+The FENCE mode field _fm_ defines the semantics of the FENCE instruction. 
+[#manual:inst:fence:operation]#A `FENCE`
 (with _fm_=`0000`) orders all memory operations in its predecessor set
-before all memory operations in its successor set.
+before all memory operations in its successor set.#
 
 A `FENCE.TSO` instruction is encoded as a FENCE instruction
-with _fm_=`1000`, _predecessor_=`RW`, and _successor_=`RW`. `FENCE.TSO` orders
+with _fm_=`1000`, _predecessor_=`RW`, and _successor_=`RW`. 
+[#manual:inst:fence.tso:operation]#`FENCE.TSO` orders
 all load operations in its predecessor set before all memory operations
 in its successor set, and all store operations in its predecessor set
 before all store operations in its successor set. This leaves `non-AMO`
 store operations in the `FENCE.TSO's` predecessor set unordered with
-`non-AMO` loads in its successor set.
+`non-AMO` loads in its successor set.#
 
 [NOTE]
 ====
+[[manual:inst:fence.tso:ordering_rw_rw_allowed]]
 Because `FENCE RW,RW` imposes a superset of the orderings that `FENCE.TSO`
 imposes, it is correct to ignore the _fm_ field and implement `FENCE.TSO` as `FENCE RW,RW`.
 ====
 
-The unused fields in the FENCE instructions--_rs1_ and _rd_--are reserved
+[#manual:inst:fence:unused_fields_reserved]#The unused fields in the FENCE 
+instructions--_rs1_ and _rd_--are reserved
 for finer-grain fences in future extensions. For forward compatibility,
-base implementations shall ignore these fields, and standard software
+base implementations shall ignore these fields#, and standard software
 shall zero these fields. Likewise, many _fm_ and predecessor/successor
 set settings are also reserved for future use.
 Base implementations shall treat all such reserved configurations as
@@ -869,6 +881,7 @@ non-reserved configurations.
 
 [NOTE]
 ====
+[[manual:inst:fence:conservative_allowed]]
 We chose a relaxed memory model to allow high performance from simple
 machine implementations and from likely future coprocessor or
 accelerator extensions. We separate out I/O ordering from memory R/W
@@ -905,13 +918,12 @@ include::images/wavedrom/env-call-breakpoint.edn[]
 These two instructions cause a precise requested trap to the supporting
 execution environment.
 
-The `ECALL` instruction is used to make a service request to the execution
-environment. The `EEI` will define how parameters for the service request
+[#manual:inst:ecall:operation]#The `ECALL` instruction is used to make a service request to the execution environment.#
+The `EEI` will define how parameters for the service request
 are passed, but usually these will be in defined locations in the
 integer register file.
 
-The `EBREAK` instruction is used to return control to a debugging
-environment.
+[#manual:inst:ebreak:operation]#The `EBREAK` instruction is used to return control to a debugging environment.#
 
 [NOTE]
 ====
@@ -986,6 +998,7 @@ _rs1_ and _rs2_ fields encode arguments to the HINT. However, a simple
 implementation can simply execute the HINT as an ADD of _rs1_ and _rs2_
 that writes `x0`, which has no architecturally visible effect.
 
+[[manual:inst:fence:null_pred_succ_intersection]]
 As another example, a FENCE instruction with a zero _pred_ field and a
 zero _fm_ field is a HINT; the _succ_, _rs1_, and _rd_ fields encode the
 arguments to the HINT. A simple implementation can simply execute the

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -136,10 +136,10 @@ RV32E subset, which only has 16 registers
 In the base RV32I ISA, there are four core instruction formats
 (R/I/S/U), as shown in <<base_instr>>. All are a fixed 32 bits in length. 
 The base ISA has `IALIGN=32`, meaning that instructions must be aligned on a four-byte boundary in memory.
-[#manual:ext:I:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
+[#manual:instgrp:taken_cti:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not `IALIGN-bit` aligned.
 This exception is reported on the branch or jump instruction, not on the target instruction.#
-[#manual:ext:I:no_ia_misaligned_exc_not_taken_br]#No instruction-address-misaligned exception is generated 
+[#manual:instgrp:cond_branch:no_ia_misaligned_exc_not_taken]#No instruction-address-misaligned exception is generated 
 for a conditional branch that is not taken.#
 
 [NOTE]
@@ -421,18 +421,18 @@ hardware.
 === Control Transfer Instructions
 RV32I provides two types of control transfer instructions: unconditional
 jumps and conditional branches. 
-[#manual:ext:I:no_cti_delay_slots]#Control transfer instructions in RV32I
+[#manual:instgrp:cti:no_cti_delay_slots]#Control transfer instructions in RV32I
 do _not_ have architecturally visible delay slots.#
 
-[#manual:ext:I:ia_fault_exc_on_target]#If an instruction access-fault or instruction page-fault exception
+[#manual:instgrp:cti:ia_fault_exc_on_target]#If an instruction access-fault or instruction page-fault exception
 occurs on the target of a jump or taken branch, the exception is
 reported on the target instruction, not on the jump or branch instruction.#
 
 ==== Unconditional Jumps
 The jump and link (JAL) instruction uses the J-type format, where the
-J-immediate encodes a signed offset in multiples of 2 bytes. The offset
-is sign-extended and added to the address of the jump instruction to
-form the jump target address. Jumps can therefore target a &#177;1 MiB range.
+J-immediate encodes a signed offset in multiples of 2 bytes.
+[#manual:inst:jal:target]#The offset is sign-extended and added to the address of the jump instruction to
+form the jump target address.# Jumps can therefore target a &#177;1 MiB range.
 [#manual:inst:jal:operation]#JAL stores the address of the instruction
 following the jump ('pc'+4) into register _rd_.#
 The standard software calling convention uses 'x1' as the return address register and 'x5' as
@@ -458,7 +458,8 @@ include::images/wavedrom/ct-unconditional.edn[]
 The indirect jump instruction JALR (jump and link register) uses the I-type encoding.
 [#manual:inst:jalr:target]#The target address is obtained by adding the
 sign-extended 12-bit I-immediate to the register _rs1_, then setting the
-least-significant bit of the result to zero. The address of the
+least-significant bit of the result to zero. 
+[#manual:inst:jalr:operation]#The address of the
 instruction following the jump (`pc`+4) is written to register _rd_.#
 Register `x0` can be used as the destination if the result is not
 required.
@@ -567,10 +568,10 @@ include::images/wavedrom/ct-conditional.edn[]
 //.Conditional branches
 
 Branch instructions compare two registers. 
-[#manual:insts:beq_bne:cmp]#BEQ and BNE take the branch if registers _rs1_ and _rs2_ are equal or unequal respectively.#
-[#manual:insts:blt_bltu:cmp]#BLT and BLTU take the branch if _rs1_ is less than _rs2_, using signed and
+[#manual:insts:beq_bne:operation]#BEQ and BNE take the branch if registers _rs1_ and _rs2_ are equal or unequal respectively.#
+[#manual:insts:blt_bltu:operation]#BLT and BLTU take the branch if _rs1_ is less than _rs2_, using signed and
 unsigned comparison respectively.#
-[#manual:insts:bge_bgeu:cmp]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_, 
+[#manual:insts:bge_bgeu:operation]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_, 
 using signed and unsigned comparison respectively.#
 Note, BGT, BGTU, BLE, and BLEU can be synthesized by
 reversing the operands to BLT, BLTU, BGE, and BGEU, respectively.
@@ -678,7 +679,7 @@ be read only, or support word access only).
 even though the load value is discarded.#
 
 [#manual:param:I:endianness:little_or_big]#The EEI will define whether the memory system is little-endian or big-endian.#
-[#manual:instgrp:load_store:endian_byte_invariant:]#In RISC-V, endianness is byte-address invariant.#
+[#manual:instgrp:load_store:endian_byte_invariant]#In RISC-V, endianness is byte-address invariant.#
 
 [NOTE]
 ====
@@ -719,7 +720,7 @@ sign-extended 12-bit offset.#
 in _rd_.#
 [#manual:inst:lhu:operation]#LHU loads a 16-bit value from memory but then zero extends to
 32-bits before storing in _rd_.# 
-[#manual:insts:lb_lhu:operation]#LB and LBU are defined analogously for 8-bit values.#
+[#manual:insts:lb_lbu:operation]#LB and LBU are defined analogously for 8-bit values.#
 [#manual:insts:sw_sh_sb:operation]#The SW, SH, and SB instructions store 32-bit, 16-bit, and
 8-bit values from the low bits of register _rs2_ to memory.#
 

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -38,7 +38,7 @@ Most of the commentary for RV32I also applies to the RV64I base.
 
 === Programmers' Model for Base Integer ISA
 
-<<gprs>> shows the unprivileged state for the base integer ISA. 
+<<gprs>> shows the unprivileged state for the base integer ISA.
 [#norm:basegrp:rv32:xregwidth]#For RV32I, the 32 `x` registers are each 32 bits wide,
 i.e., `XLEN=32`.# [#norm:basegrp:all:x0eq0]#Register `x0` is hardwired with all bits equal to 0.#
 [#norm:bases:rv32i_rv64i:other-xregs]#General purpose registers `x1-x31` hold values that various
@@ -134,7 +134,7 @@ RV32E subset, which only has 16 registers
 ====
 === Base Instruction Formats
 In the base RV32I ISA, there are four core instruction formats
-(R/I/S/U), as shown in <<base_instr>>. All are a fixed 32 bits in length. 
+(R/I/S/U), as shown in <<base_instr>>. All are a fixed 32 bits in length.
 The base ISA has `IALIGN=32`, meaning that instructions must be aligned on a four-byte boundary in memory.
 [#norm:instgrp:taken_cti:ia_misaligned_exc]#An instruction-address-misaligned exception is generated on a taken branch
 or unconditional jump if the target address is not `IALIGN-bit` aligned.
@@ -326,7 +326,7 @@ include::images/wavedrom/int-comp-slli-srli-srai.edn[]
 Shifts by a constant are encoded as a specialization of the I-type
 format. The operand to be shifted is in _rs1_, and the shift amount is
 encoded in the lower 5 bits of the I-immediate field. The right shift
-type is encoded in bit 30. 
+type is encoded in bit 30.
 [#norm:inst:slli:operation]#SLLI is a logical left shift (zeros are shifted into the lower bits);#
 [#norm:inst:srli:operation]#SRLI is a logical right shift (zeros are shifted into the upper bits);# and
 [#norm:inst:srai:operation]#SRAI is an arithmetic right shift (the original sign bit is copied into the vacated upper bits).#
@@ -340,7 +340,7 @@ LUI (load upper immediate) is used to build 32-bit constants and uses the U-type
 destination register _rd_, filling in the lowest 12 bits with zeros.#
 
 AUIPC (add upper immediate to `pc`) is used to build `pc`-relative
-addresses and uses the U-type format. 
+addresses and uses the U-type format.
 [#norm:inst:auipc:operation]#AUIPC forms a 32-bit offset from
 the U-immediate, filling in the lowest 12 bits with zeros, adds this
 offset to the address of the AUIPC instruction, then places the result
@@ -375,9 +375,9 @@ include::images/wavedrom/int-reg-reg.edn[]
 [[int-reg-reg]]
 //.Integer register-register
 
-[#norm:inst:add:operation]#ADD performs the addition of _rs1_ and _rs2_.# 
+[#norm:inst:add:operation]#ADD performs the addition of _rs1_ and _rs2_.#
 [#norm:inst:sub:operation]#SUB performs the subtraction of _rs2_ from _rs1_.#
-[#norm:insts:add_sub:overflow]#Overflows are ignored and the low XLEN bits of results are written to the destination _rd_.# 
+[#norm:insts:add_sub:overflow]#Overflows are ignored and the low XLEN bits of results are written to the destination _rd_.#
 [#norm:insts:slt_sltu:operation]#SLT and SLTU perform signed and unsigned compares respectively, writing 1 to _rd_ if
 _rs1_ < _rs2_, 0 otherwise.#
 Note, SLTU _rd_, _x0_, _rs2_ sets _rd_ to 1 if _rs2_ is not equal to zero,
@@ -420,7 +420,7 @@ hardware.
 
 === Control Transfer Instructions
 RV32I provides two types of control transfer instructions: unconditional
-jumps and conditional branches. 
+jumps and conditional branches.
 [#norm:instgrp:cti:no_cti_delay_slots]#Control transfer instructions in RV32I
 do _not_ have architecturally visible delay slots.#
 
@@ -558,7 +558,7 @@ is only pushed to enable macro-op fusion of the sequences:
 
 ==== Conditional Branches
 
-All branch instructions use the B-type instruction format. 
+All branch instructions use the B-type instruction format.
 [#norm:instgrp:branch:target]#The 12-bit B-immediate encodes signed offsets in multiples of 2 bytes. The offset
 is sign-extended and added to the address of the branch instruction to give the target address.#
 The conditional branch range is &#177;4 KiB.
@@ -567,11 +567,11 @@ include::images/wavedrom/ct-conditional.edn[]
 [[ct-conditional]]
 //.Conditional branches
 
-Branch instructions compare two registers. 
+Branch instructions compare two registers.
 [#norm:insts:beq_bne:operation]#BEQ and BNE take the branch if registers _rs1_ and _rs2_ are equal or unequal respectively.#
 [#norm:insts:blt_bltu:operation]#BLT and BLTU take the branch if _rs1_ is less than _rs2_, using signed and
 unsigned comparison respectively.#
-[#norm:insts:bge_bgeu:operation]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_, 
+[#norm:insts:bge_bgeu:operation]#BGE and BGEU take the branch if _rs1_ is greater than or equal to _rs2_,
 using signed and unsigned comparison respectively.#
 Note, BGT, BGTU, BLE, and BLEU can be synthesized by
 reversing the operands to BLT, BLTU, BGE, and BGEU, respectively.
@@ -711,7 +711,7 @@ include::images/wavedrom/load-store.edn[]
 Load and store instructions transfer a value between the registers and
 memory. Loads are encoded in the I-type format and stores are S-type.
 [#norm:instgrp:load_store:ea]#The effective address is obtained by adding register _rs1_ to the
-sign-extended 12-bit offset.# 
+sign-extended 12-bit offset.#
 [#norm:instgrp:load:operation]#Loads copy a value from memory to register _rd_.#
 [#norm:instgrp:store:operation]#Stores copy the value in register _rs2_ to memory.#
 
@@ -719,7 +719,7 @@ sign-extended 12-bit offset.#
 [#norm:inst:lh:operation]#LH loads a 16-bit value from memory, then sign-extends to 32-bits before storing
 in _rd_.#
 [#norm:inst:lhu:operation]#LHU loads a 16-bit value from memory but then zero extends to
-32-bits before storing in _rd_.# 
+32-bits before storing in _rd_.#
 [#norm:insts:lb_lbu:operation]#LB and LBU are defined analogously for 8-bit values.#
 [#norm:insts:sw_sh_sb:operation]#The SW, SH, and SB instructions store 32-bit, 16-bit, and
 8-bit values from the low bits of register _rs2_ to memory.#
@@ -733,11 +733,11 @@ size of the access in bytes) have behavior dependent on the EEI.#
 An EEI may guarantee that misaligned loads and stores are fully
 supported, and so the software running inside the execution environment
 will never experience a contained or fatal address-misaligned trap. In this case, the
-[#norm:param:I:misaligned_ldst:fully_hw_supported]#misaligned loads and stores can be handled in hardware#, or 
+[#norm:param:I:misaligned_ldst:fully_hw_supported]#misaligned loads and stores can be handled in hardware#, or
 [#norm:param:I:misaligned_ldst:invisible_trap]#via an invisible trap into the execution environment implementation#, or possibly a
 [#norm:param:I:misaligned_ldst:hw_or_invisible_trap_func_of_addr]#combination of hardware and invisible trap depending on address.#
 
-An EEI may not guarantee misaligned loads and stores are handled invisibly. In this case, 
+An EEI may not guarantee misaligned loads and stores are handled invisibly. In this case,
 [#norm:param:I:misaligned_ldst:fully_hw_supported_or_visible_trap]#loads and stores that are not naturally aligned
 may either complete execution successfully or raise an exception.#
 [#norm:instgrp:load_store:addr_misaligned_or_access_fault_exc]#The exception raised can be either an
@@ -779,7 +779,7 @@ very simplified addressing modes (e.g., register indirect only).
 Even when misaligned loads and stores complete successfully, these
 accesses might run extremely slowly depending on the implementation
 (e.g., when implemented via an invisible trap). Furthermore, whereas
-[#norm:instgrp:load_store:atomicity_for_aligned]#naturally aligned 
+[#norm:instgrp:load_store:atomicity_for_aligned]#naturally aligned
 loads and stores are guaranteed to execute atomically#,
 misaligned loads and stores might not, and hence require additional
 synchronization to ensure atomicity.
@@ -849,13 +849,13 @@ FENCE instruction.
 |_other_|_other_ |_Reserved for future use._
 |===
 
-The FENCE mode field _fm_ defines the semantics of the FENCE instruction. 
+The FENCE mode field _fm_ defines the semantics of the FENCE instruction.
 [#norm:inst:fence:operation]#A `FENCE`
 (with _fm_=`0000`) orders all memory operations in its predecessor set
 before all memory operations in its successor set.#
 
 A `FENCE.TSO` instruction is encoded as a FENCE instruction
-with _fm_=`1000`, _predecessor_=`RW`, and _successor_=`RW`. 
+with _fm_=`1000`, _predecessor_=`RW`, and _successor_=`RW`.
 [#norm:inst:fence.tso:operation]#`FENCE.TSO` orders
 all load operations in its predecessor set before all memory operations
 in its successor set, and all store operations in its predecessor set
@@ -870,7 +870,7 @@ Because `FENCE RW,RW` imposes a superset of the orderings that `FENCE.TSO`
 imposes, it is correct to ignore the _fm_ field and implement `FENCE.TSO` as `FENCE RW,RW`.
 ====
 
-[#norm:inst:fence:unused_fields_reserved]#The unused fields in the FENCE 
+[#norm:inst:fence:unused_fields_reserved]#The unused fields in the FENCE
 instructions--_rs1_ and _rd_--are reserved
 for finer-grain fences in future extensions. For forward compatibility,
 base implementations shall ignore these fields#, and standard software


### PR DESCRIPTION
Using this as a pilot case to share with stakeholders (e.g., ARC, Doc SIG) what it will look like to start tagging the ISA manual with normative rule text used to create normative rules in the CSC test plans. Will also be useful for processor implementations to understand RISC-V better even if they don't plan on getting a certificate for their implementation.

You'll need a version of the docs_resources with my associated PR in it. See https://github.com/riscv/docs-resources/pull/54.