### PR TITLE
Copy priv/unpriv ISA manual HTML to same directory as norm-rules.html

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -150,6 +150,8 @@ jobs:
           cp build/norm-rules.html dist/snapshot/norm-rules/index.html
           cp build/norm-rules.html dist/snapshot/norm-rules/norm-rules.html
           cp build/norm-rules.json dist/snapshot/norm-rules/norm-rules.json
+          cp build/riscv-unprivileged.html dist/snapshot/norm-rules/unprivileged.html
+          cp build/riscv-privileged.html dist/snapshot/norm-rules/privileged.html
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
       - name: Upload pages artifact


### PR DESCRIPTION
Mimicking how they are all in the build directory so norm-rules.html can find the links into the priv/unpriv html the same as a local build