### PR TITLE
Remove c-jalr entry from c-st-ext.yaml

### DIFF
--- a/normative_rule_defs/c-st-ext.yaml
+++ b/normative_rule_defs/c-st-ext.yaml
@@ -63,8 +63,6 @@ normative_rule_definitions:
     tags: ["norm:c-jr_rsv"]
   - name: c-jalr_op
     tags: ["norm:c-jalr_op"]
-  - name: c-jalr
-    tags: ["norm:c-jalr_ebreak"]
   - name: c-ebreak
     tags: ["norm:c-jalr_ebreak"]
   - name: c-beqz_op


### PR DESCRIPTION
Removed the 'c-jalr' entry from the YAML file.  Redundant with the c-ebreak entry with the same tag and the c_jalr_op entry with the main operation.