### PR TITLE
Update WARL field type and constraints explanation

### DIFF
--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -1190,6 +1190,12 @@ read of a *WARL* field when the last write was of an illegal value, but the
 legal value returned should deterministically depend on the illegal
 written value and the architectural state of the hart.
 
+If the CSR field type is not otherwise mentioned, it is *WARL*.  
+Some *WARL* fields specify constraints, such as being read-only 0
+if a certain extension is not supported.  If constraints are unspecified,
+the implmentation may choose any range of supported values, including
+all values, read-only 0, read-only nonzero, etc.
+
 === CSR Field Modulation
 
 If a write to one CSR changes the set of legal values allowed for a


### PR DESCRIPTION
Clarify CSR field type and constraints for WARL fields.

Per Allen Baum email on tech-privileged 4/2/26 7:01 am
```
There are places in the spec that are explicit that a field is WARL but must not be readOnly1. In the absence of that, I would infer that it is not prohibited; it could be RW or RO1 or RO0.
```

The text about "not explicitly mentioned" refers to registers such as mscratch or mcause.Interrupt our mseccfg.USEED whose type is not specified.  Alternatively I could check all of the CSR fields and make a PR to call them out as WARL explicitly